### PR TITLE
Update Docker image URLs to use correct ghcr.io registry

### DIFF
--- a/Company-Project/docker-compose.yml
+++ b/Company-Project/docker-compose.yml
@@ -52,7 +52,7 @@ services:
             - ./src:/app/src:cached
 
     wp-cli:
-        image: frojd/wp-cli-php-8.1:latest
+        image: ghcr.io/frojd/dockerimages/wp-cli-php-8.1:latest
         links:
             - db
         volumes:
@@ -64,7 +64,7 @@ services:
             - ./docker/files/db-dumps:/app/db-dumps
 
     composer:
-        image: frojd/composer-php-8.1:latest
+        image: ghcr.io/frojd/dockerimages/composer-php-8.1:latest
         command: install
         volumes:
             - ./src:/app/src

--- a/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/{{cookiecutter.project_name}}/docker-compose.yml
@@ -52,7 +52,7 @@ services:
             - ./src:/app/src:cached
 
     wp-cli:
-        image: ghci.io/frojd/dockerimages/wp-cli-php-8.1:latest
+        image: ghcr.io/frojd/dockerimages/wp-cli-php-8.1:latest
         links:
             - db
         volumes:
@@ -64,7 +64,7 @@ services:
             - ./docker/files/db-dumps:/app/db-dumps
 
     composer:
-        image: ghci.io/frojd/dockerimages/composer-php-8.1:latest
+        image: ghcr.io/frojd/dockerimages/composer-php-8.1:latest
         command: install
         volumes:
             - ./src:/app/src


### PR DESCRIPTION
Replace incorrect ghci.io registry URLs with ghcr.io in wp-cli and composer service definitions in docker-compose.yml. 